### PR TITLE
Fix `format` for data.frame containing summaries

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -254,7 +254,7 @@ new_summary_metadata <- function(plugin_name = character(), display_name = chara
 
 #' @export
 format.tfevents_summary <- function(x, ...) {
-  format(vctrs::field(x, "value"))
+  sapply(x, format)
 }
 
 #' @export

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -142,3 +142,18 @@ test_that("collect_event with type fails", {
   )
 
 })
+
+test_that("can format a data frame containing summaries", {
+
+
+  temp <- tempfile()
+  with_logdir(temp, {
+    log_event(hello = summary_histogram(runif(1000)))
+    log_event(bye = 1)
+  })
+
+  x <- collect_events(temp)
+  expect_error(as.data.frame(x), regexp = NA)
+  expect_error(format(as.data.frame(x)), regexp = NA)
+
+})


### PR DESCRIPTION
Partially deals with #30 