### PR TITLE
Windows: update protobuf

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,13 +44,10 @@ jobs:
           needs: check
 
       - name: Install Python libraries used for testing
+        continue-on-error: true
         run: |
           reticulate::py_install(c("tbparse", "tensorflow"), pip = TRUE)
         shell: Rscript {0}
-
-      - if: ${{ matrix.config.os == 'macos-latest' }}
-        run: |
-          brew install protobuf
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,11 +1,9 @@
-# ProtoBuf Version
-VERSION = 3.19.4
-RWINLIB = ../windows/protobuf-${VERSION}
-
+RWINLIB = ../windows/protobuf
 PKG_CPPFLAGS= -I$(RWINLIB)/include -Igenerated
 PKG_LIBS= -L$(RWINLIB)/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} \
-	-L$(RWINLIB)/lib${R_ARCH}${CRT} \
+	-L$(RWINLIB)/lib \
 	-lprotobuf
+BINDIR=$(RWINLIB)/bin$(subst 64,,$(WIN))
 
 OBJECTS = \
 		generated/event.pb.o \
@@ -36,9 +34,9 @@ OBJECTS = \
 all: clean winlibs
 
 winlibs:
-	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
 	mkdir generated
-	find proto -name *.proto -exec bash -c '"${RWINLIB}/bin$(WIN)/protoc" -I "proto" --cpp_out="generated" {}' \;
+	find proto -name *.proto -exec bash -c '"${BINDIR}/protoc" -I "proto" --cpp_out="generated" {}' \;
 
 clean:
 	rm -f $(OBJECTS) $(SHLIB)

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,9 +1,18 @@
-# Build against protobuf libs compiled with Rtools
-VERSION <- commandArgs(TRUE)
-if (!file.exists(sprintf("../windows/protobuf-%s/include/google/protobuf/descriptor.h", VERSION))) {
-  if (getRversion() < "3.3.0") setInternet2()
-  download.file(sprintf("https://github.com/rwinlib/protobuf/archive/%s.zip", VERSION), "lib.zip", quiet = TRUE)
+if(!file.exists("../windows/protobuf/include/google/protobuf/descriptor.h")){
+  unlink("../windows", recursive = TRUE)
+  url <- if(grepl("aarch", R.version$platform)){
+    "https://github.com/r-windows/bundles/releases/download/protobuf-21.12/protobuf-21.12-clang-aarch64.tar.xz"
+  } else if(grepl("clang", Sys.getenv('R_COMPILED_BY'))){
+    "https://github.com/r-windows/bundles/releases/download/protobuf-21.12/protobuf-21.12-clang-x86_64.tar.xz"
+  } else if(getRversion() >= "4.3") {
+    "https://github.com/r-windows/bundles/releases/download/protobuf-21.12/protobuf-21.12-ucrt-x86_64.tar.xz"
+  } else {
+    "https://github.com/rwinlib/protobuf/archive/v21.12.tar.gz"
+  }
+  download.file(url, basename(url), quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
-  unzip("lib.zip", exdir = "../windows")
-  unlink("lib.zip")
+  untar(basename(url), exdir = "../windows", tar = 'internal')
+  unlink(basename(url))
+  setwd("../windows")
+  file.rename(list.files(), 'protobuf')
 }


### PR DESCRIPTION
This updates the version of protobuf on windows to add support for the new arm64 hardware. Same setup as CRAN version of protolite.